### PR TITLE
hardcode aws sdk to 1.9.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ With Amazon Polly, you only pay for what you use. You are charged based on the n
 
 
 
-> 🛑 Before proceeding you must have Unreal Engine 4.26 or later installed as well as the Microsoft Visual Studio development tools required for UE4 C++ development (Windows) or the Xcode development tools (Mac). If you need help with these setup steps, refer to the Unreal Engine 4 documentation, especially ["Setting Up Visual Studio for Unreal Engine"](https://docs.unrealengine.com/4.26/en-US/ProductionPipelines/DevelopmentSetup/VisualStudioSetup/).
+> 🛑 Before proceeding you must have Unreal Engine 4.26 or 4.27 installed as well as the Microsoft Visual Studio development tools required for UE4 C++ development (Windows) or the Xcode development tools (Mac). If you need help with these setup steps, refer to the Unreal Engine 4 documentation, especially ["Setting Up Visual Studio for Unreal Engine"](https://docs.unrealengine.com/4.26/en-US/ProductionPipelines/DevelopmentSetup/VisualStudioSetup/). Disclaimer: This was only tested with Visual Studio 2019 with UE4.26, although with slight modifications to the build script it should work with Visual Studio 2022 as well. I couldn't get this to work with UE5.
 
 
 
@@ -53,7 +53,7 @@ Use the `aws configure` command to create a default profile for the AWS CLI. Be 
 
 ### 3. Compile the Polly C++ SDK
 
-> 🛑 This next step requires cmake. If you don't already have cmake installed, you can [download it here](https://cmake.org/download/). After you download cmake, launch cmake and click 'Tools' -> 'How To Install For Command Line Use' and follow one of the instructions. E.g. for Mac - One may add CMake to the PATH: PATH="/Applications/CMake.app/Contents/bin":"$PATH"
+> 🛑 This next step requires cmake and git. If you don't already have cmake installed, you can [download it here](https://cmake.org/download/). After you download cmake, launch cmake and click 'Tools' -> 'How To Install For Command Line Use' and follow one of the instructions. E.g. for Mac - One may add CMake to the PATH: PATH="/Applications/CMake.app/Contents/bin":"$PATH"
 
 This project makes use of the C++ Polly API – a part of the AWS SDK for C++ – to communicate with the Polly service. We've provided scripts to automatically download and compile the appropriate binaries for you. Run one of the following scripts:
 

--- a/Source/AmazonPollyMetaHuman/ThirdParty/AwsSdk/BuildAwsSdkMac.sh
+++ b/Source/AmazonPollyMetaHuman/ThirdParty/AwsSdk/BuildAwsSdkMac.sh
@@ -5,10 +5,11 @@ SDK_REPO_DIR="$SCRIPT_DIR/aws-sdk-cpp"
 SDK_BUILD_DIR="$SDK_REPO_DIR/_build"
 SDK_INSTALL_DIR="$SDK_REPO_DIR/_install"
 MODULE_MAC_DIR="$SCRIPT_DIR/Mac"
+AWS_SDK_VERSION="1.9.0"
 
 # Clone the repo
 cd "$SCRIPT_DIR"
-git clone --recurse-submodules https://github.com/aws/aws-sdk-cpp.git
+git clone --branch $AWS_SDK_VERSION --recurse-submodules https://github.com/aws/aws-sdk-cpp.git
 
 # Create build and install directories where we will build and install the SDK to
 cd "$SDK_REPO_DIR"

--- a/Source/AmazonPollyMetaHuman/ThirdParty/AwsSdk/BuildAwsSdkWin64.bat
+++ b/Source/AmazonPollyMetaHuman/ThirdParty/AwsSdk/BuildAwsSdkWin64.bat
@@ -1,3 +1,5 @@
+@ECHO OFF
+
 SET EXITCODE=0
 
 SET SCRIPT_DIR=%~dp0
@@ -5,6 +7,7 @@ SET SDK_REPO_DIR=%SCRIPT_DIR%aws-sdk-cpp\
 SET SDK_BUILD_DIR=%SDK_REPO_DIR%_build\
 SET SDK_INSTALL_DIR=%SDK_REPO_DIR%_install\
 SET MODULE_WIN64_DIR=%SCRIPT_DIR%Win64\
+SET AWS_SDK_VERSION=1.9.0
 
 @REM Find and run VsDevCmd.bat to add the msbuild command to Path
 SET VS_INSTALLPATH=
@@ -30,7 +33,7 @@ CALL "%VS_INSTALLPATH%\Common7\Tools\VsDevCmd.bat"
 @REM Clone the repo
 IF NOT EXIST "%SDK_REPO_DIR%" (
     PUSHD "%SCRIPT_DIR%"
-    git clone -c core.longpaths=true --recurse-submodules https://github.com/aws/aws-sdk-cpp.git
+    git clone -c core.longpaths=true --branch %AWS_SDK_VERSION% --recurse-submodules https://github.com/aws/aws-sdk-cpp.git
     IF %ERRORLEVEL% NEQ 0 ( POPD & GOTO FAILED )
     POPD
 


### PR DESCRIPTION
*Description of changes:*

Modify build scripts to clone the aws sdk at version 1.9.0. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
